### PR TITLE
Add -support_by_pp option to the use JSON line

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.07
+	- add -support_by_pp flag, so JSON will use JSON::PP if PP-only features
+	  (like escape_slash) are requested.
+
 0.06
 	- add json_decode method patch by Leo Lapworth
 

--- a/lib/Template/Plugin/JSON.pm
+++ b/lib/Template/Plugin/JSON.pm
@@ -3,13 +3,13 @@
 package Template::Plugin::JSON;
 use Moose;
 
-use JSON ();
+use JSON -support_by_pp, -no_export;
 
 use Carp qw/croak/;
 
 extends qw(Moose::Object Template::Plugin);
 
-our $VERSION = "0.06";
+our $VERSION = "0.07";
 
 
 has context => (
@@ -112,6 +112,11 @@ It will load the L<JSON> module (you probably want L<JSON::XS> installed for
 automatic speed ups).
 
 Any options on the USE line are passed through to the JSON object, much like L<JSON/to_json>.
+The C<-support_by_pp> flag is enabled, so it's possible to use options only
+supported by L<JSON::PP>, such as C<escape_slash> (something that's fairly
+important if embedding JSON into HTML without creating XSS problems). However
+if you do use JSON::PP-only features, L<JSON> will create a L<JSON::PP> object
+instead of a L<JSON::XS> object, which will impact speed a little.
 
 =head1 SEE ALSO
 

--- a/t/support-by-pp.t
+++ b/t/support-by-pp.t
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Template;
+
+use ok 'Template::Plugin::JSON';
+
+ok(Template->new->process(
+	\q{[% USE JSON ( escape_slash => 1 ) %][% foo.json %]},
+	{ foo => ['woo/bar'] },
+	\(my $out),
+), "Template processing") || warn Template->error;
+
+is($out, q{["woo\/bar"]}, "escape_slash option properly honoured");
+
+done_testing;


### PR DESCRIPTION
This allows the use of JSON::PP features (like escape_slash), with the caveat that it'll drop to JSON::PP rather than JSON::XS.
